### PR TITLE
JavaScript file call error fix

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -37,7 +37,7 @@ class DateTimePicker(DateTimeInput):
                         'fa-ir': 'fa-ir',
                         'fr-ca': 'fr-ca',
                         'ms-my': 'ms-my',
-                        'pt-br': 'bt-BR',
+                        'pt-br': 'pt-BR',
                         'rs-latin': 'rs-latin',
                         'tzm-la': 'tzm-la',
                         'tzm': 'tzm',


### PR DESCRIPTION
Change from "bt-br" to "pt-br" to call the file "bootstrap-datetimepicker.br.js"